### PR TITLE
refactor(sync): extract local task reconciliation from google tasks service

### DIFF
--- a/src/services/google-tasks-sync.ts
+++ b/src/services/google-tasks-sync.ts
@@ -7,20 +7,8 @@ import { App, Notice, TAbstractFile, TFile, debounce, normalizePath } from "obsi
 import { GoogleTasksToken, TemporalDriftSettings, TaskMeta, GoogleTasksSyncStatus, GoogleTasksSyncStats } from "../types";
 import { GoogleAuthSession } from "./google/auth/google-auth-session";
 import { GoogleTasksRemoteClient } from "./google/tasks/google-tasks-remote-client";
-import {
-  buildObsidianNotes,
-  canonicalStatus,
-  decodeTaskTitle,
-  emptyPreviewCounts,
-  emptySyncStats,
-  encodeDueDay,
-  normalizeDueDay,
-  parseObsidianPathFromNotes,
-  parseRemoteDone,
-  sanitizeFileName,
-  isoDay,
-  toRemotePatch,
-} from "./google/tasks/task-codec";
+import { LocalTaskReconciliation } from "./google/tasks/local-task-reconciliation";
+import { emptyPreviewCounts, emptySyncStats, parseObsidianPathFromNotes } from "./google/tasks/task-codec";
 import {
   GoogleTask,
   GoogleTaskList,
@@ -45,6 +33,7 @@ export class GoogleTasksSyncService {
   private token: GoogleTasksToken | null;
   private auth: GoogleAuthSession;
   private remoteClient: GoogleTasksRemoteClient;
+  private localReconciliation: LocalTaskReconciliation;
 
   private syncInProgress = false;
   private debouncedSync: (() => void) | null = null;
@@ -99,6 +88,19 @@ export class GoogleTasksSyncService {
       onTokenRefresh: () => {
         this.token = this.auth.getToken() as GoogleTasksToken | null;
       },
+    });
+
+    this.localReconciliation = new LocalTaskReconciliation({
+      app: this.app,
+      getTasksFolder: () => this.settings.tasksFolder,
+      getFrontmatter: this.getFrontmatter.bind(this),
+      getLocalTaskMeta: this.getLocalTaskMeta.bind(this),
+      computeSyncStamp: this.computeSyncStamp.bind(this),
+      writeSyncMeta: this.writeSyncMeta.bind(this),
+      patchRemoteTask: this.patchRemoteTask.bind(this),
+      fetchRemoteTaskById: this.fetchRemoteTaskById.bind(this),
+      logSyncDecision: this.logSyncDecision.bind(this),
+      getHttpStatus: this.getHttpStatus.bind(this),
     });
 
     this.setupDebouncedSync();
@@ -283,20 +285,10 @@ export class GoogleTasksSyncService {
     });
   }
 
-  private remotePayloadFromLocal(local: TaskMeta, remote?: GoogleTask): Partial<Pick<GoogleTask, "title" | "status" | "due" | "notes">> {
-    return toRemotePatch(local, remote);
-  }
+  // moved to LocalTaskReconciliation
 
   private remoteMatchesLocal(local: TaskMeta, remote: GoogleTask): boolean {
-    const expected = this.remotePayloadFromLocal(local, remote);
-    const remoteDue = normalizeDueDay(remote.due);
-    const expectedDue = normalizeDueDay(expected.due);
-    return (
-      remote.title === expected.title &&
-      remote.status === expected.status &&
-      remoteDue === expectedDue &&
-      parseObsidianPathFromNotes(remote.notes) === local.path
-    );
+    return this.localReconciliation.remoteMatchesLocal(local, remote);
   }
 
   private logSyncDecision(action: string, payload: Record<string, unknown>): void {

--- a/src/services/google/tasks/local-task-reconciliation.ts
+++ b/src/services/google/tasks/local-task-reconciliation.ts
@@ -1,0 +1,269 @@
+// ============================================================================
+// Google Tasks - Local Reconciliation Helpers
+// ============================================================================
+
+import { App, TFile, normalizePath } from "obsidian";
+
+import { TaskMeta } from "../../../types";
+import {
+  buildObsidianNotes,
+  canonicalStatus,
+  decodeTaskTitle,
+  isoDay,
+  normalizeDueDay,
+  parseObsidianPathFromNotes,
+  parseRemoteDone,
+  sanitizeFileName,
+  toRemotePatch,
+} from "./task-codec";
+import { GoogleTask } from "./types";
+
+interface SyncMeta {
+  id: string;
+  etag: string;
+  lastSynced: number;
+}
+
+interface LocalTaskReconciliationOptions {
+  app: App;
+  getTasksFolder: () => string;
+  getFrontmatter: (file: TFile) => Record<string, any>;
+  getLocalTaskMeta: (file: TFile) => TaskMeta;
+  computeSyncStamp: (file: TFile, local?: TaskMeta) => number;
+  writeSyncMeta: (file: TFile, meta: SyncMeta) => Promise<void>;
+  patchRemoteTask: (
+    listId: string,
+    taskId: string,
+    patch: Partial<Pick<GoogleTask, "title" | "status" | "due" | "notes">>,
+    opts?: { ifMatchEtag?: string }
+  ) => Promise<GoogleTask>;
+  fetchRemoteTaskById: (listId: string, taskId: string) => Promise<GoogleTask>;
+  logSyncDecision: (action: string, payload: Record<string, unknown>) => void;
+  getHttpStatus: (error: unknown) => number | null;
+}
+
+export class LocalTaskReconciliation {
+  private app: App;
+  private getTasksFolder: () => string;
+  private getFrontmatter: (file: TFile) => Record<string, any>;
+  private getLocalTaskMeta: (file: TFile) => TaskMeta;
+  private computeSyncStamp: (file: TFile, local?: TaskMeta) => number;
+  private writeSyncMeta: (file: TFile, meta: SyncMeta) => Promise<void>;
+  private patchRemoteTask: (
+    listId: string,
+    taskId: string,
+    patch: Partial<Pick<GoogleTask, "title" | "status" | "due" | "notes">>,
+    opts?: { ifMatchEtag?: string }
+  ) => Promise<GoogleTask>;
+  private fetchRemoteTaskById: (listId: string, taskId: string) => Promise<GoogleTask>;
+  private logSyncDecision: (action: string, payload: Record<string, unknown>) => void;
+  private getHttpStatus: (error: unknown) => number | null;
+
+  constructor(options: LocalTaskReconciliationOptions) {
+    this.app = options.app;
+    this.getTasksFolder = options.getTasksFolder;
+    this.getFrontmatter = options.getFrontmatter;
+    this.getLocalTaskMeta = options.getLocalTaskMeta;
+    this.computeSyncStamp = options.computeSyncStamp;
+    this.writeSyncMeta = options.writeSyncMeta;
+    this.patchRemoteTask = options.patchRemoteTask;
+    this.fetchRemoteTaskById = options.fetchRemoteTaskById;
+    this.logSyncDecision = options.logSyncDecision;
+    this.getHttpStatus = options.getHttpStatus;
+  }
+
+  remotePayloadFromLocal(local: TaskMeta, remote?: GoogleTask): Partial<Pick<GoogleTask, "title" | "status" | "due" | "notes">> {
+    return toRemotePatch(local, remote);
+  }
+
+  remoteMatchesLocal(local: TaskMeta, remote: GoogleTask): boolean {
+    const expected = this.remotePayloadFromLocal(local, remote);
+    const remoteDue = normalizeDueDay(remote.due);
+    const expectedDue = normalizeDueDay(expected.due);
+    return (
+      remote.title === expected.title &&
+      remote.status === expected.status &&
+      remoteDue === expectedDue &&
+      parseObsidianPathFromNotes(remote.notes) === local.path
+    );
+  }
+
+  async applyRemoteToLocal(file: TFile, remote: GoogleTask, listId: string): Promise<void> {
+    const decoded = decodeTaskTitle(remote.title);
+    const done = parseRemoteDone(remote.status);
+
+    // Ensure the remote has up-to-date mapping note.
+    const mappedPath = parseObsidianPathFromNotes(remote.notes);
+    if (mappedPath !== file.path) {
+      const next = await this.patchRemoteTask(
+        listId,
+        remote.id,
+        { notes: buildObsidianNotes(file.path, remote.notes) },
+        { ifMatchEtag: remote.etag }
+      );
+      remote = next;
+    }
+
+    // Update frontmatter only when it actually changes.
+    const fm = this.getFrontmatter(file);
+    const nextStatus = canonicalStatus(done);
+    const nextDone = done;
+    const nextPriority = decoded.priority;
+
+    const needsFrontmatterUpdate =
+      String(fm.status ?? "") !== nextStatus ||
+      Boolean(fm.done ?? false) !== nextDone ||
+      String(fm.priority ?? "") !== nextPriority;
+
+    if (needsFrontmatterUpdate) {
+      await this.app.fileManager.processFrontMatter(file, (frontmatter) => {
+        frontmatter.status = nextStatus;
+        (frontmatter as any).done = nextDone;
+        frontmatter.priority = nextPriority;
+      });
+    }
+
+    // Update first checkbox line (best-effort) without write-churn on no-op.
+    const original = await this.app.vault.read(file);
+    const lines = original.split("\n");
+    const idx = lines.findIndex((l) => l.match(/^(?:\s*-\s*)?\[\s*[xX ]\s*\]/));
+    const checkbox = done ? "[x]" : "[ ]";
+    const priority = decoded.priority ? ` #${decoded.priority}` : "";
+
+    let nextContent = original;
+    if (idx >= 0) {
+      const rest = lines[idx].replace(/^(\s*-?\s*)\[\s*[xX ]\s*\]\s*/, "");
+      const cleaned = rest
+        .replace(/(?:^|\s)(?:#now|#next|#later|@now|@next|@later|\[now\]|\[next\]|\[later\]|\(now\)|\(next\)|\(later\))(?=\s|$)/gi, " ")
+        .replace(/\s{2,}/g, " ")
+        .trim();
+      lines[idx] = `- ${checkbox} ${cleaned}${priority}`.trim();
+      nextContent = lines.join("\n");
+    } else {
+      const head = `- ${checkbox} ${decoded.title}${priority}`.trim();
+      nextContent = `${head}\n${original}`;
+    }
+
+    if (nextContent !== original) {
+      await this.app.vault.modify(file, nextContent);
+    }
+
+    const localAfter = this.getLocalTaskMeta(file);
+    await this.writeSyncMeta(file, {
+      id: remote.id,
+      etag: remote.etag,
+      lastSynced: this.computeSyncStamp(file, localAfter),
+    });
+  }
+
+  async pushLocalToRemote(file: TFile, local: TaskMeta, remote: GoogleTask, listId: string): Promise<GoogleTask> {
+    const patch = this.remotePayloadFromLocal(local, remote);
+
+    // Avoid remote write churn when already in desired state.
+    if (this.remoteMatchesLocal(local, remote)) {
+      await this.writeSyncMeta(file, {
+        id: remote.id,
+        etag: remote.etag,
+        lastSynced: this.computeSyncStamp(file, local),
+      });
+      this.logSyncDecision("remote_noop", { path: file.path, taskId: remote.id });
+      return remote;
+    }
+
+    try {
+      const next = await this.patchRemoteTask(listId, remote.id, patch, {
+        ifMatchEtag: local.googleEtag || remote.etag,
+      });
+
+      await this.writeSyncMeta(file, {
+        id: next.id,
+        etag: next.etag,
+        lastSynced: this.computeSyncStamp(file, local),
+      });
+
+      this.logSyncDecision("remote_patch", {
+        path: file.path,
+        taskId: next.id,
+        reason: "local_changed",
+      });
+
+      return next;
+    } catch (error) {
+      const status = this.getHttpStatus(error);
+
+      // ETag race: fetch fresh, then deterministically apply local-wins once.
+      if (status === 409 || status === 412) {
+        this.logSyncDecision("remote_etag_conflict", {
+          path: file.path,
+          taskId: remote.id,
+          status,
+          strategy: "local_wins_retry_once",
+        });
+
+        const latest = await this.fetchRemoteTaskById(listId, remote.id);
+        const retried = await this.patchRemoteTask(listId, remote.id, this.remotePayloadFromLocal(local, latest), {
+          ifMatchEtag: latest.etag,
+        });
+
+        await this.writeSyncMeta(file, {
+          id: retried.id,
+          etag: retried.etag,
+          lastSynced: this.computeSyncStamp(file, local),
+        });
+
+        this.logSyncDecision("remote_patch_retry", {
+          path: file.path,
+          taskId: retried.id,
+        });
+
+        return retried;
+      }
+
+      throw error;
+    }
+  }
+
+  suggestLocalPathForRemote(remote: GoogleTask, occupied?: Set<string>): string {
+    const decoded = decodeTaskTitle(remote.title);
+    const safe = sanitizeFileName(decoded.title) || `Google Task ${isoDay(new Date())}`;
+
+    let path = normalizePath(`${this.getTasksFolder()}/${safe}.md`);
+    const baseId = sanitizeFileName(remote.id).slice(0, 8) || String(Date.now());
+    let bump = 0;
+
+    const isTaken = (candidate: string): boolean => {
+      if (occupied?.has(candidate)) return true;
+      return this.app.vault.getAbstractFileByPath(candidate) instanceof TFile;
+    };
+
+    while (isTaken(path)) {
+      bump += 1;
+      const suffix = bump === 1 ? baseId : `${baseId}-${bump}`;
+      path = normalizePath(`${this.getTasksFolder()}/${safe} (${suffix}).md`);
+    }
+
+    return path;
+  }
+
+  async ensureLocalFromRemote(remote: GoogleTask): Promise<TFile | null> {
+    const mappedPath = parseObsidianPathFromNotes(remote.notes);
+    if (mappedPath) {
+      const af = this.app.vault.getAbstractFileByPath(mappedPath);
+      if (af instanceof TFile) return af;
+    }
+
+    // Create a new local task note in Tasks/
+    const decoded = decodeTaskTitle(remote.title);
+    const done = parseRemoteDone(remote.status);
+
+    const path = this.suggestLocalPathForRemote(remote);
+
+    const checkbox = done ? "[x]" : "[ ]";
+    const priority = decoded.priority ? ` #${decoded.priority}` : "";
+
+    const content = `---\nstatus: ${canonicalStatus(done)}\npriority: ${decoded.priority}\ndone: ${done}\ncreated: ${isoDay(new Date())}\n---\n\n- ${checkbox} ${decoded.title}${priority}\n`;
+
+    const file = await this.app.vault.create(path, content);
+    return file;
+  }
+}


### PR DESCRIPTION
## Summary\n- extract local reconciliation logic out of \n- keep behavior unchanged while reducing service complexity\n\n## Verification\n- npm run build\n- npm run test:unit\n\n## Notes\nClean recovery from interrupted run (SIGKILL), isolated to Google Tasks split only.